### PR TITLE
fix(polyfills): Symbol.toStringTag throws an error when undefined

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -244,6 +244,7 @@
         case toStringTag:
           descriptor = O.getOwnPropertyDescriptor(ObjectProto, 'toString');
           descriptor.value = function () {
+            if(typeof this === 'undefined') return 'undefined';
             var
               str = toString.call(this),
               tst = this[Symbol.toStringTag]


### PR DESCRIPTION
For some obscure reason when trying to use `moment` I was getting the following error:

```
TypeError: Cannot read property 'Symbol(toStringTag)' of undefined
```

This is a very simple fix to avoid trying to read `Syymbol(toStringTag)` of undefined