### PR TITLE
toStringTag fails if this is undefined

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -246,7 +246,7 @@
           descriptor.value = function () {
             var
               str = toString.call(this),
-              tst = this[Symbol.toStringTag]
+              tst = typeof this === 'undefined' ? undefined : this[Symbol.toStringTag]
             ;
             return typeof tst === 'undefined' ? str : ('[object ' + tst + ']');
           };


### PR DESCRIPTION
I am using `github:js-data/js-data@^2.9.0` library and it started to fail with `aurelia-polyfills@1.0.0-beta.1.0.2`
it was working with `1.0.0-beta.1.0.1`