### PR TITLE
fix(symbol): fix Object.defineProperties

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -24,7 +24,7 @@ import {PLATFORM} from 'aurelia-pal';
     create = Object.create,
     keys = Object.keys,
     defineProperty = Object[DP],
-    defineProperties = Object[DPies],
+    $defineProperties = Object[DPies],
     descriptor = gOPD(Object, GOPN),
     ObjectProto = Object.prototype,
     hOP = ObjectProto.hasOwnProperty,
@@ -146,7 +146,7 @@ import {PLATFORM} from 'aurelia-pal';
         }
       });
     } else {
-      defineProperties(o, descriptors);
+      $defineProperties(o, descriptors);
     }
     return o;
   };


### PR DESCRIPTION
Using `Object.defineProperties` with the `Symbol` polyfill would throw error. It was fixed in https://github.com/WebReflection/get-own-property-symbols/commit/f815d673b2f1d667ce34a39338b32536f53246a8. This PR applies the same changes here.