### PR TITLE
Fixing IE 11 issues

### DIFF
--- a/dist/amd/aurelia-polyfills.js
+++ b/dist/amd/aurelia-polyfills.js
@@ -109,6 +109,10 @@ define(['aurelia-pal'], function (_aureliaPal) {
       return o;
     },
         $getOwnPropertySymbols = function getOwnPropertySymbols(o) {
+
+      var cof = {}.toString.call(o).slice(8, -1);
+      o = cof == 'String' ? o.split('') : Object(o);
+
       return gOPN(o).filter(onlySymbols).map(sourceMap);
     };
 
@@ -283,7 +287,7 @@ define(['aurelia-pal'], function (_aureliaPal) {
         return isNaN(it = +it) ? 0 : (it > 0 ? Math.floor : Math.ceil)(it);
       };
       var toLength = function toLength(it) {
-        return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0;
+        return it > 0 ? Math.min(toInteger(it), 0x1fffffffffffff) : 0;
       };
       var iterCall = function iterCall(iter, fn, a1, a2) {
         try {

--- a/dist/aurelia-polyfills.js
+++ b/dist/aurelia-polyfills.js
@@ -122,6 +122,10 @@ import {PLATFORM} from 'aurelia-pal';
       return o;
     },
     $getOwnPropertySymbols = function getOwnPropertySymbols(o) {
+
+        var cof = {}.toString.call(o).slice(8, -1);
+        o = (cof == 'String') ? o.split('') : Object(o);
+
       return gOPN(o).filter(onlySymbols).map(sourceMap);
     }
   ;
@@ -339,8 +343,8 @@ if (!Array.from) {
     var toInteger = function(it) {
       return isNaN(it = +it) ? 0 : (it > 0 ? Math.floor : Math.ceil)(it);
     };
-    var toLength = function(it) { 
-      return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991 
+    var toLength = function(it) {
+      return it > 0 ? Math.min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
     };
     var iterCall = function(iter, fn, a1, a2) {
       try {

--- a/dist/commonjs/aurelia-polyfills.js
+++ b/dist/commonjs/aurelia-polyfills.js
@@ -110,6 +110,10 @@ var _aureliaPal = require('aurelia-pal');
     return o;
   },
       $getOwnPropertySymbols = function getOwnPropertySymbols(o) {
+
+    var cof = {}.toString.call(o).slice(8, -1);
+    o = cof == 'String' ? o.split('') : Object(o);
+
     return gOPN(o).filter(onlySymbols).map(sourceMap);
   };
 
@@ -284,7 +288,7 @@ if (!Array.from) {
       return isNaN(it = +it) ? 0 : (it > 0 ? Math.floor : Math.ceil)(it);
     };
     var toLength = function toLength(it) {
-      return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0;
+      return it > 0 ? Math.min(toInteger(it), 0x1fffffffffffff) : 0;
     };
     var iterCall = function iterCall(iter, fn, a1, a2) {
       try {

--- a/dist/es2015/aurelia-polyfills.js
+++ b/dist/es2015/aurelia-polyfills.js
@@ -108,6 +108,10 @@ import { PLATFORM } from 'aurelia-pal';
     return o;
   },
       $getOwnPropertySymbols = function getOwnPropertySymbols(o) {
+
+    var cof = {}.toString.call(o).slice(8, -1);
+    o = cof == 'String' ? o.split('') : Object(o);
+
     return gOPN(o).filter(onlySymbols).map(sourceMap);
   };
 
@@ -282,7 +286,7 @@ if (!Array.from) {
       return isNaN(it = +it) ? 0 : (it > 0 ? Math.floor : Math.ceil)(it);
     };
     var toLength = function (it) {
-      return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0;
+      return it > 0 ? Math.min(toInteger(it), 0x1fffffffffffff) : 0;
     };
     var iterCall = function (iter, fn, a1, a2) {
       try {

--- a/dist/system/aurelia-polyfills.js
+++ b/dist/system/aurelia-polyfills.js
@@ -116,6 +116,10 @@ System.register(['aurelia-pal'], function (_export, _context) {
           return o;
         },
             $getOwnPropertySymbols = function getOwnPropertySymbols(o) {
+
+          var cof = {}.toString.call(o).slice(8, -1);
+          o = cof == 'String' ? o.split('') : Object(o);
+
           return gOPN(o).filter(onlySymbols).map(sourceMap);
         };
 
@@ -290,7 +294,7 @@ System.register(['aurelia-pal'], function (_export, _context) {
             return isNaN(it = +it) ? 0 : (it > 0 ? Math.floor : Math.ceil)(it);
           };
           var toLength = function toLength(it) {
-            return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0;
+            return it > 0 ? Math.min(toInteger(it), 0x1fffffffffffff) : 0;
           };
           var iterCall = function iterCall(iter, fn, a1, a2) {
             try {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",
+    "through2": "^2.0.1",
     "vinyl": "^0.5.1",
     "vinyl-paths": "^1.0.0",
     "yargs": "^2.1.1"

--- a/src/array.js
+++ b/src/array.js
@@ -3,8 +3,8 @@ if (!Array.from) {
     var toInteger = function(it) {
       return isNaN(it = +it) ? 0 : (it > 0 ? Math.floor : Math.ceil)(it);
     };
-    var toLength = function(it) { 
-      return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991 
+    var toLength = function(it) {
+      return it > 0 ? Math.min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
     };
     var iterCall = function(iter, fn, a1, a2) {
       try {

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -122,6 +122,10 @@ import {PLATFORM} from 'aurelia-pal';
       return o;
     },
     $getOwnPropertySymbols = function getOwnPropertySymbols(o) {
+
+        var cof = {}.toString.call(o).slice(8, -1);
+        o = (cof == 'String') ? o.split('') : Object(o);
+
       return gOPN(o).filter(onlySymbols).map(sourceMap);
     }
   ;


### PR DESCRIPTION
Fixed issue related to bug  #16.

"Potentially unhandled rejection [1] TypeError: Object.getOwnPropertyNames: argument is not an Object"

It's happening when Strings are being passed to Symbol.getOwnPropertySymbols method. Added a fix based on core.js implementation.

Also fixed issue in Array.from method. Changed "min" to "Math.min" as it was causing reference errors on IE 11.

