### PR TITLE
Add polyfill for Reflect.defineProperty

### DIFF
--- a/src/reflect.js
+++ b/src/reflect.js
@@ -32,6 +32,20 @@ if (typeof Reflect.metadata !== 'function') {
   };
 }
 
+if (typeof Reflect.defineProperty !== 'function') {
+  Reflect.defineProperty = function(target, propertyKey, descriptor) {
+    if (typeof target !== 'object') {
+      throw new TypeError('Reflect.defineProperty called on non-object');
+    }
+    try {
+      Object.defineProperty(target, propertyKey, descriptor);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+}
+
 if (typeof Reflect.construct !== 'function') {
   Reflect.construct = function(Target, args) {
     if (args) {


### PR DESCRIPTION
`Reflect.defineProperty` can be used as an alternative for `Object.defineProperty` without the need for try-and-catching. See also [aurelia-binding#342](https://github.com/aurelia/binding/pull/342).