### PR TITLE
fix(reflect): fix target-is-object check

### DIFF
--- a/src/reflect.js
+++ b/src/reflect.js
@@ -34,7 +34,7 @@ if (typeof Reflect.metadata !== 'function') {
 
 if (typeof Reflect.defineProperty !== 'function') {
   Reflect.defineProperty = function(target, propertyKey, descriptor) {
-    if (typeof target !== 'object') {
+    if (typeof target === 'object' ? target === null : typeof target !== 'function') {
       throw new TypeError('Reflect.defineProperty called on non-object');
     }
     try {


### PR DESCRIPTION
Fix checking for non-null objects as suggested by [doktordirk](https://github.com/aurelia/binding/pull/342#issuecomment-216202989).