### PR TITLE
fix(array): make Array.from work with mapping functions

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -6,9 +6,9 @@ if (!Array.from) {
     var toLength = function(it) {
       return it > 0 ? Math.min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
     };
-    var iterCall = function(iter, fn, a1, a2) {
+    var iterCall = function(iter, fn, val, index) {
       try {
-        fn(a1, a2);
+        return fn(val, index)
       }
       catch (E) {
         if (typeof iter.return == 'function') iter.return();
@@ -29,7 +29,7 @@ if (!Array.from) {
       if (mapping) mapfn = mapfn.bind(aLen > 2 ? arguments[2] : undefined);
       if (iterFn != undefined && !Array.isArray(arrayLike)) {
         for (iterator = iterFn.call(O), result = new C; !(step = iterator.next()).done; index++) {
-          result[index] = mapping ? iterCall(mapfn, step.value, index) : step.value;
+          result[index] = mapping ? iterCall(iterator, mapfn, step.value, index) : step.value;
         }
       } else {
         length = toLength(O.length);


### PR DESCRIPTION
Issue referenced at:
https://github.com/aurelia/polyfills/issues/4#issuecomment-246473333
Previous behavior resulted in errors thrown when passing a mapping
function to the polyfill `Array.from`
This allows you to properly allow a mapping function and a “thisArg” to
follow spec listed
(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from)