### PR TITLE
add Math polyfill

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-polyfills",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The minimal set of polyfills that the Aurelia platform needs to run on ES5 browsers.",
   "keywords": [
     "aurelia",

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "aurelia-polyfills",
+  "name": "fin-polyfills",
   "version": "1.1.2",
   "description": "The minimal set of polyfills that the Aurelia platform needs to run on ES5 browsers.",
   "keywords": [

--- a/build/paths.js
+++ b/build/paths.js
@@ -26,6 +26,7 @@ var paths = {
 
 paths.files = [
   'symbol.js',
+  'math.js',
   'number.js',
   'string.js',
   'array.js',

--- a/dist/amd/aurelia-polyfills.js
+++ b/dist/amd/aurelia-polyfills.js
@@ -4,7 +4,7 @@ define(['aurelia-pal'], function (_aureliaPal) {
   var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
     return typeof obj;
   } : function (obj) {
-    return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj;
+    return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
   };
 
   (function (Object, GOPS) {
@@ -259,6 +259,10 @@ define(['aurelia-pal'], function (_aureliaPal) {
       return iterator;
     };
   })(Symbol.iterator, Array.prototype, String.prototype);
+
+  Math.log2 = Math.log2 || function (x) {
+    return Math.log(x) * Math.LOG2E;
+  };
 
   Number.isNaN = Number.isNaN || function (value) {
     return value !== value;

--- a/dist/aurelia-polyfills.js
+++ b/dist/aurelia-polyfills.js
@@ -311,6 +311,10 @@ import {PLATFORM} from 'aurelia-pal';
 
 }(Symbol.iterator, Array.prototype, String.prototype));
 
+Math.log2 = Math.log2 || function (x) {
+    return Math.log(x) * Math.LOG2E;
+};
+
 Number.isNaN = Number.isNaN || function(value) {     
   return value !== value;
 };

--- a/dist/commonjs/aurelia-polyfills.js
+++ b/dist/commonjs/aurelia-polyfills.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _aureliaPal = require('aurelia-pal');
 
@@ -256,6 +256,10 @@ var _aureliaPal = require('aurelia-pal');
     return iterator;
   };
 })(Symbol.iterator, Array.prototype, String.prototype);
+
+Math.log2 = Math.log2 || function (x) {
+  return Math.log(x) * Math.LOG2E;
+};
 
 Number.isNaN = Number.isNaN || function (value) {
   return value !== value;

--- a/dist/es2015/aurelia-polyfills.js
+++ b/dist/es2015/aurelia-polyfills.js
@@ -253,6 +253,10 @@ import { PLATFORM } from 'aurelia-pal';
   };
 })(Symbol.iterator, Array.prototype, String.prototype);
 
+Math.log2 = Math.log2 || function (x) {
+  return Math.log(x) * Math.LOG2E;
+};
+
 Number.isNaN = Number.isNaN || function (value) {
   return value !== value;
 };

--- a/dist/native-modules/aurelia-polyfills.js
+++ b/dist/native-modules/aurelia-polyfills.js
@@ -1,4 +1,4 @@
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 import { PLATFORM } from 'aurelia-pal';
 
@@ -254,6 +254,10 @@ import { PLATFORM } from 'aurelia-pal';
     return iterator;
   };
 })(Symbol.iterator, Array.prototype, String.prototype);
+
+Math.log2 = Math.log2 || function (x) {
+  return Math.log(x) * Math.LOG2E;
+};
 
 Number.isNaN = Number.isNaN || function (value) {
   return value !== value;

--- a/dist/system/aurelia-polyfills.js
+++ b/dist/system/aurelia-polyfills.js
@@ -13,7 +13,7 @@ System.register(['aurelia-pal'], function (_export, _context) {
       _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
         return typeof obj;
       } : function (obj) {
-        return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj;
+        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
       };
 
 
@@ -269,6 +269,10 @@ System.register(['aurelia-pal'], function (_export, _context) {
           return iterator;
         };
       })(Symbol.iterator, Array.prototype, String.prototype);
+
+      Math.log2 = Math.log2 || function (x) {
+        return Math.log(x) * Math.LOG2E;
+      };
 
       Number.isNaN = Number.isNaN || function (value) {
         return value !== value;

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -8,7 +8,7 @@ System.register(['./aurelia-polyfills'], function (_export, _context) {
       var _exportObj = {};
 
       for (var _key in _aureliaPolyfills) {
-        if (_key !== "default" && key !== "__esModule") _exportObj[_key] = _aureliaPolyfills[_key];
+        if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _aureliaPolyfills[_key];
       }
 
       _export(_exportObj);

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="1.1.2"></a>
+## [1.1.2](https://github.com/aurelia/polyfills/compare/1.1.1...v1.1.2) (2016-11-27)
+
+
+
 <a name="1.1.1"></a>
 ## [1.1.1](https://github.com/aurelia/polyfills/compare/1.1.0...v1.1.1) (2016-09-13)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-polyfills",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The minimal set of polyfills that the Aurelia platform needs to run on ES5 browsers.",
   "keywords": [
     "aurelia",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aurelia-polyfills",
+  "name": "fin-polyfills",
   "version": "1.1.2",
   "description": "The minimal set of polyfills that the Aurelia platform needs to run on ES5 browsers.",
   "keywords": [

--- a/src/math.js
+++ b/src/math.js
@@ -1,0 +1,3 @@
+Math.log2 = Math.log2 || function (x) {
+    return Math.log(x) * Math.LOG2E;
+};


### PR DESCRIPTION
IE doesn't support `Math.log2`. A `math.js` file has been added with a polyfill for this method.

![image](https://cloud.githubusercontent.com/assets/9957358/20645012/c82e1c0e-b401-11e6-855e-670830d7b1ca.png)
