### PR TITLE
refactor(size): opt-out for polyfills

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -1,3 +1,5 @@
+if (typeof FEATURE_NO_ES2015 === 'undefined') {
+
 if (!Array.from) {
   Array.from = (function () {
     var toInteger = function(it) {
@@ -99,7 +101,9 @@ if (!Array.prototype.findIndex) {
   });
 }
 
-if (!Array.prototype.includes) {
+} // endif FEATURE_NO_ES2015
+
+if (typeof FEATURE_NO_ES2016 === 'undefined' && !Array.prototype.includes) {
   Object.defineProperty(Array.prototype, 'includes', {
     configurable: true,
     writable: true,

--- a/src/collections.js
+++ b/src/collections.js
@@ -1,5 +1,7 @@
 import {PLATFORM} from 'aurelia-pal';
 
+if (typeof FEATURE_NO_ES2015 === 'undefined') {
+  
 (function (global) {
   //shared pointer
   var i;
@@ -233,3 +235,5 @@ import {PLATFORM} from 'aurelia-pal';
   }
 
 })(PLATFORM.global);
+
+} // endif (FEATURE_NO_ES2015)

--- a/src/number.js
+++ b/src/number.js
@@ -1,3 +1,5 @@
+if (typeof FEATURE_NO_ES2015 === 'undefined') {
+
 Number.isNaN = Number.isNaN || function(value) {     
   return value !== value;
 };
@@ -5,3 +7,5 @@ Number.isNaN = Number.isNaN || function(value) {
 Number.isFinite = Number.isFinite || function(value) {
   return typeof value === "number" && isFinite(value);
 };
+
+} // endif FEATURE_NO_ES2015

--- a/src/object.js
+++ b/src/object.js
@@ -1,3 +1,5 @@
+if (typeof FEATURE_NO_ES2015 === 'undefined') {
+
 (function() {
   let needsFix = false;
 
@@ -103,3 +105,5 @@
       }())
     });
 }(Object));
+
+} // endif FEATURE_NO_ES2015

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,35 +1,11 @@
 import {PLATFORM} from 'aurelia-pal';
 
-const emptyMetadata = Object.freeze({});
-const metadataContainerKey = '__metadata__';
+if (typeof FEATURE_NO_ES2015 === 'undefined') {
+
 const bind = Function.prototype.bind;
 
 if (typeof PLATFORM.global.Reflect === 'undefined') {
   PLATFORM.global.Reflect = {};
-}
-
-if (typeof Reflect.getOwnMetadata !== 'function') {
-  Reflect.getOwnMetadata = function(metadataKey, target, targetKey) {
-    if (target.hasOwnProperty(metadataContainerKey)) {
-      return (target[metadataContainerKey][targetKey] || emptyMetadata)[metadataKey];
-    }
-  };
-}
-
-if (typeof Reflect.defineMetadata !== 'function') {
-  Reflect.defineMetadata = function(metadataKey, metadataValue, target, targetKey) {
-    let metadataContainer = target.hasOwnProperty(metadataContainerKey) ? target[metadataContainerKey] : (target[metadataContainerKey] = {});
-    let targetContainer = metadataContainer[targetKey] || (metadataContainer[targetKey] = {});
-    targetContainer[metadataKey] = metadataValue;
-  };
-}
-
-if (typeof Reflect.metadata !== 'function') {
-  Reflect.metadata = function(metadataKey, metadataValue) {
-    return function(target, targetKey) {
-      Reflect.defineMetadata(metadataKey, metadataValue, target, targetKey);
-    };
-  };
 }
 
 if (typeof Reflect.defineProperty !== 'function') {
@@ -67,3 +43,36 @@ if (typeof Reflect.construct !== 'function') {
 if (typeof Reflect.ownKeys !== 'function') {
   Reflect.ownKeys = function(o) { return (Object.getOwnPropertyNames(o).concat(Object.getOwnPropertySymbols(o))); }
 }
+
+} // endif FEATURE_NO_ES2015
+
+if (typeof FEATURE_NO_ESNEXT === 'undefined') {
+
+const emptyMetadata = Object.freeze({});
+const metadataContainerKey = '__metadata__';
+
+if (typeof Reflect.getOwnMetadata !== 'function') {
+  Reflect.getOwnMetadata = function(metadataKey, target, targetKey) {
+    if (target.hasOwnProperty(metadataContainerKey)) {
+      return (target[metadataContainerKey][targetKey] || emptyMetadata)[metadataKey];
+    }
+  };
+}
+
+if (typeof Reflect.defineMetadata !== 'function') {
+  Reflect.defineMetadata = function(metadataKey, metadataValue, target, targetKey) {
+    let metadataContainer = target.hasOwnProperty(metadataContainerKey) ? target[metadataContainerKey] : (target[metadataContainerKey] = {});
+    let targetContainer = metadataContainer[targetKey] || (metadataContainer[targetKey] = {});
+    targetContainer[metadataKey] = metadataValue;
+  };
+}
+
+if (typeof Reflect.metadata !== 'function') {
+  Reflect.metadata = function(metadataKey, metadataValue) {
+    return function(target, targetKey) {
+      Reflect.defineMetadata(metadataKey, metadataValue, target, targetKey);
+    };
+  };
+}
+
+} // endif FEATURE_NO_ESNEXT

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -1,5 +1,7 @@
 import {PLATFORM} from 'aurelia-pal';
 
+if (typeof FEATURE_NO_ES2015 === 'undefined') {
+
 (function (Object, GOPS) {'use strict';
 
   // (C) Andrea Giammarchi - Mit Style
@@ -310,3 +312,6 @@ import {PLATFORM} from 'aurelia-pal';
   };
 
 }(Symbol.iterator, Array.prototype, String.prototype));
+
+
+} // endif FEATURE_NO_ES2015


### PR DESCRIPTION
Put every polyfill behind a global free variable `FEATURE_NO_ES5`, `FEATURE_NO_ES6`, `FEATURE_NO_ESNEXT` based on its standard support.

This enables build tools such as webpack to opt-out of some polyfills. Keeping only `esnext` (i.e. the `Reflect.metadata` polyfills) reduces the minified build by approx. 10K.