### PR TITLE
fix(symbols): check that descriptors is an object

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -49,11 +49,13 @@ if (typeof FEATURE_NO_ES2015 === 'undefined') {
     },
     createWithSymbols = function (proto, descriptors) {
       var self = create(proto);
-      gOPN(descriptors).forEach(function (key) {
-        if (propertyIsEnumerable.call(descriptors, key)) {
-          $defineProperty(self, key, descriptors[key]);
-        }
-      });
+      if (descriptors !== null && typeof descriptors === 'object') {
+        gOPN(descriptors).forEach(function (key) {
+          if (propertyIsEnumerable.call(descriptors, key)) {
+            $defineProperty(self, key, descriptors[key]);
+          }
+        });
+      }
       return self;
     },
     copyAsNonEnumerable = function (descriptor) {


### PR DESCRIPTION
In IE, createWithSymbols fails if descriptors is undefined, giving the following error:
"Object.getOwnPropertyNames: argument is not an Object"
This makes sure the item is an object before continuing.

I've not been able to run the test suite on this yet. (Running out of time for the day, so I figured even if I have to come back later and fix it up, this could benefit people in between time). This is my first time contributing to an aurelia repo, so I'm unfamiliar with the build process and that kind of thing. 