### PR TITLE
fix(symbols): propertyIsEnumerable null reference

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -76,6 +76,7 @@ if (typeof FEATURE_NO_ES2015 === 'undefined') {
       var uid = '' + key;
       return onlySymbols(uid) ? (
         hOP.call(this, uid) &&
+        this[internalSymbol] &&
         this[internalSymbol]['@@' + uid]
       ) : pIE.call(this, key);
     },


### PR DESCRIPTION
Fixes an issue in IE 11 where `this[internalSymbol]` can be undefined